### PR TITLE
 docsify-dark-mode: * fix onlyCover option breaking dark-mode

### DIFF
--- a/packages/docsify-dark-mode/src/index.js
+++ b/packages/docsify-dark-mode/src/index.js
@@ -53,6 +53,10 @@ const plugin = (hook, vm) => {
     }
 
     var checkbox = document.querySelector('input[name=mode]')
+    
+    if (!checkbox) {
+      return
+    }
 
     checkbox.addEventListener('change', function() {
       // dark


### PR DESCRIPTION
onlyCover will prevent the button from being rendered so the script will throw an error. This can be prevented by checking if the checkbox exists